### PR TITLE
Do not pass PEM CAs to NSS

### DIFF
--- a/src/jsonrpc/connectors/httpclient.cpp
+++ b/src/jsonrpc/connectors/httpclient.cpp
@@ -69,6 +69,13 @@ namespace jsonrpc
             throw JsonRpcException(Errors::ERROR_CLIENT_CONNECTOR, ": libcurl initialization error");
         }
 
+        // When using curl-NSS, need to set to NULL because we don't
+        // have the PEM reader on 16.04. SSL_DIR is set to an NSS store
+        // with the root CAs in it.
+        if (std::getenv("SSL_DIR"))
+        {
+            curl_easy_setopt(curl, CURLOPT_CAINFO, NULL);
+        }
         curl_easy_setopt(curl, CURLOPT_URL, this->url.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
     }


### PR DESCRIPTION
On Ubuntu 16.04, the PEM reader (libnsspem.so) isn't available, it
wasn't added until 18.04. So passing the PEM-encoded system root CAs
just causes an error.

Instead, when SSL_DIR is set (which I believe is NSS-only), don't pass
any. Instead, you can import them into that SSL_DIR.

[TABLET-2596]